### PR TITLE
Use libary to output valid JSON

### DIFF
--- a/fontaine/builder.py
+++ b/fontaine/builder.py
@@ -11,6 +11,7 @@
 
 from __future__ import print_function
 import csv
+import json
 import io
 import os
 import sys
@@ -304,8 +305,7 @@ class Builder(object):
 
     @staticmethod
     def json_(tree):
-        items_length = 0
-        pprint(tree, indent='', items_length=items_length)
+        print(json.dumps(tree, indent=2, sort_keys=False))
 
     @staticmethod
     def csv_(fonts, _library=library):


### PR DESCRIPTION
Closes #110.

At least on my system, the module used by `import json` is in the base Python install, the same place the one for `import csv` used in the same location is, so I assume the is safe to use without adding dependencies to the project, but I am not super familiar with the Python ecosystem, so I'm open to suggestions if there is a better way to implement this.

Adding the 2 space indentation enables formatted output, which I think is much human friendly than the one line monster being output previously, but that's also just my preference. I'm happy to change this if somebody else feels strongly on the matter.