### PR TITLE
Fix Unicode charset for python 3

### DIFF
--- a/fontaine/font.py
+++ b/fontaine/font.py
@@ -182,8 +182,9 @@ class CharsetInfo(object):
         glyphs = getattr(self.charset, 'glyphs', [])
         if callable(glyphs):
             glyphs = glyphs()
+        glyphs = list(glyphs) or []
 
-        self.glyphs_in_charset_count = len(list(glyphs) or [])
+        self.glyphs_in_charset_count = len(glyphs)
 
         self.hits = 0
         for char in glyphs:
@@ -192,7 +193,7 @@ class CharsetInfo(object):
             else:
                 self.hits += 1
 
-        self.glyphs_count = len(list(glyphs))
+        self.glyphs_count = len(glyphs)
         if self.hits == self.glyphs_count:
             self.coverage = 100
             self.support_level = SUPPORT_LEVEL_FULL


### PR DESCRIPTION
convert_to_list_of_unicodes returns a map object.

In Python3, a map object can only be list-ified once, so when we come to listify it again for glyphs_count, we get an empty list. My font doesn’t support any of those glyphs, 0==0 and I have full support for most of Unicode!

Why we have a distinction between glyphs_count and glyphs_in_charset_count is beyond me, though...