### PR TITLE
Update README.rst installation info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,11 @@ First, install Python and the `pip <http://www.pip-installer.org>`__ python pack
 
 Install the latest release easily with pip::
 
-    sudo pip3 install fontaine
+    sudo pip3 install fontaine --user;
 
 To install the latest development version::
 
-    sudo pip3 install https://github.com/googlefonts/pyfontaine/archive/master.zip;
+    sudo pip3 install https://github.com/googlefonts/pyfontaine/archive/master.zip --user;
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -19,22 +19,21 @@ All files in the `internals <https://github.com/googlefonts/pyfontaine/tree/mast
 Installation
 ------------
 
-First, install Python and the `pip <http://www.pip-installer.org>`__ python package manager. This is installed by default with `homebrew <http://brew.sh/>`__ python, so, install homebrew, then install pip as follows::
+First, install Python and the `pip <http://www.pip-installer.org>`__ python package manager. This is installed by default with `homebrew <http://brew.sh/>`__ python, so, install homebrew, then install the neccessary depedencies (`PyICU <https://pypi.org/project/PyICU/>`__) as follows::
 
-    brew install python;
-    brew install icu4c;
-
-On Mac OS X, install the pyicu dependency as follows::
-
-    CFLAGS=-I/usr/local/opt/icu4c/include LDFLAGS=-L/usr/local/opt/icu4c/lib pip install pyicu;
+    brew install python icu4c pkg-config;
+    export PATH="/usr/local/opt/icu4c/bin:/usr/local/opt/icu4c/sbin:$PATH";
+    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/icu4c/lib/pkgconfig";
+    export CC="$(which gcc)" CXX="$(which g++)";
+    pip3 install --no-binary=:pyicu: pyicu;
 
 Install the latest release easily with pip::
 
-    sudo pip install fontaine
+    sudo pip3 install fontaine
 
 To install the latest development version::
 
-    sudo pip install https://github.com/googlefonts/pyfontaine/archive/master.zip;
+    sudo pip3 install https://github.com/googlefonts/pyfontaine/archive/master.zip;
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Install the latest release easily with pip::
 
 To install the latest development version::
 
-    pip3 install https://github.com/googlefonts/pyfontaine/archive/main.zip --user;
+    pip3 install git+https://github.com/googlefonts/pyfontaine.git#egg=fontaine --user;
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,11 @@ First, install Python and the `pip <http://www.pip-installer.org>`__ python pack
 
 Install the latest release easily with pip::
 
-    sudo pip3 install fontaine --user;
+    pip3 install fontaine --user;
 
 To install the latest development version::
 
-    sudo pip3 install https://github.com/googlefonts/pyfontaine/archive/master.zip --user;
+    pip3 install https://github.com/googlefonts/pyfontaine/archive/main.zip --user;
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,6 @@ To install the latest development version::
     pip3 install git+https://github.com/googlefonts/pyfontaine.git#egg=fontaine --user;
 
 
-
-If someone could confirm that this is correct it would be nice to add this to the readme or I could open a PR.
-
 Usage
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ All files in the `internals <https://github.com/googlefonts/pyfontaine/tree/mast
 Installation
 ------------
 
+macOS:
+
 First, install Python and the `pip <http://www.pip-installer.org>`__ python package manager. This is installed by default with `homebrew <http://brew.sh/>`__ python, so, install homebrew, then install the neccessary depedencies (`PyICU <https://pypi.org/project/PyICU/>`__) as follows::
 
     brew install python icu4c pkg-config;
@@ -27,6 +29,10 @@ First, install Python and the `pip <http://www.pip-installer.org>`__ python pack
     export CC="$(which gcc)" CXX="$(which g++)";
     pip3 install --no-binary=:pyicu: pyicu;
 
+Debian:
+
+    apt-get install libicu-dev
+
 Install the latest release easily with pip::
 
     pip3 install fontaine --user;
@@ -34,6 +40,10 @@ Install the latest release easily with pip::
 To install the latest development version::
 
     pip3 install git+https://github.com/googlefonts/pyfontaine.git#egg=fontaine --user;
+
+
+
+If someone could confirm that this is correct it would be nice to add this to the readme or I could open a PR.
 
 Usage
 -----


### PR DESCRIPTION
This resolved the issues I found with the previous instructions, but I still didn't get a `pyfontaine` executable in my PATH as expected.

However, the module is available

```
% python3
Python 3.9.5 (default, May  4 2021, 03:36:27) 
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import fontaine
>>> 
```

Fixes #125 and #109 and #113